### PR TITLE
Ensure that factories return an object

### DIFF
--- a/src/FactoryTestTrait.php
+++ b/src/FactoryTestTrait.php
@@ -59,7 +59,7 @@ trait FactoryTestTrait
             [
                 'factories' => [
                     'service' => function () {
-                        return func_get_args();
+                        return new TestAsset\FactoryService(func_get_args());
                     },
                 ],
             ],
@@ -73,7 +73,7 @@ trait FactoryTestTrait
     {
         $container = $this->createContainer($config);
 
-        $args = $container->get('service');
+        $args = $container->get('service')->args;
         self::assertGreaterThanOrEqual(2, $args);
         // Not testing for identical $container argument here, as some implementations
         // may decorate another container in order to fulfill the config contracts.

--- a/src/TestAsset/FactoryService.php
+++ b/src/TestAsset/FactoryService.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace Zend\ContainerConfigTest\TestAsset;
 
-use Psr\Container\ContainerInterface;
-
-function factoryWithName(ContainerInterface $container, string $name) : FactoryService
+class FactoryService
 {
-    return new FactoryService(func_get_args());
+    public $args = [];
+
+    public function __construct(array $args)
+    {
+        $this->args = $args;
+    }
 }

--- a/src/TestAsset/FactoryStatic.php
+++ b/src/TestAsset/FactoryStatic.php
@@ -18,8 +18,8 @@ class FactoryStatic
         return new Service();
     }
 
-    public static function withName() : array
+    public static function withName() : FactoryService
     {
-        return func_get_args();
+        return new FactoryService(func_get_args());
     }
 }

--- a/src/TestAsset/FactoryWithName.php
+++ b/src/TestAsset/FactoryWithName.php
@@ -11,8 +11,8 @@ namespace Zend\ContainerConfigTest\TestAsset;
 
 class FactoryWithName
 {
-    public function __invoke() : array
+    public function __invoke() : FactoryService
     {
-        return func_get_args();
+        return new FactoryService(func_get_args());
     }
 }


### PR DESCRIPTION
Some containers (eg: Auryn) require that all returns are objects.

Discovered while working on northwoods/container#11.
